### PR TITLE
Keep example up to date

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -9,4 +9,4 @@
     :copyright: (c) 2015 by Vital Kudzelka <vital.kudzelka@gmail.com>
     :license: MIT
 """
-__version__ = '0.3.1'
+__version__ = '0.4.0'

--- a/app/assets.py
+++ b/app/assets.py
@@ -43,7 +43,7 @@ cssmain = Bundle(
     'stylesheets/main.less',
     debug=False,
     depends=('**/*.less'),
-    filters=('less', 'cssmin', copyright),
+    filters=('less', 'autoprefixer', 'cssmin', copyright),
     output='dist/main.%(version)s.css'
 )
 

--- a/app/dev.cfg
+++ b/app/dev.cfg
@@ -11,6 +11,13 @@ SECRET_KEY = os.environ.get('SECRET_KEY', 'my-secret')
 # otherwise.
 ASSETS_DEBUG = DEBUG
 
+AUTOPREFIXER_BIN = os.path.abspath(os.path.join(
+    os.path.dirname(__file__), os.pardir, 'node_modules', '.bin', 'postcss'
+))
+AUTOPREFIXER_EXTRA_ARGS = (
+    '--use', 'autoprefixer'
+)
+
 # Include vendor directory for less command line.
 LESS_PATHS = ('vendor',)
 

--- a/app/static/stylesheets/components/button.less
+++ b/app/static/stylesheets/components/button.less
@@ -7,7 +7,7 @@
     border: none;
 
     // Round corners.
-    .border-radius(.2em);
+    border-radius: .2em;
 
     // Use antialiasing font smoothing method to counter bold effect on OSX.
     font-weight: bold;
@@ -15,30 +15,30 @@
     -webkit-font-smoothing: antialiased;
 
     // Prevent button text selection.
-    .user-select(none);
+    user-select: none;
 
     color: #333;
     background-color: #fafafa;
-    .background-image(linear-gradient(rgba(255,255,255,.15), rgba(0,0,0,.1)));
-    .box-shadow(0 -1px 0 0 rgba(0,0,0,.05) inset,
+    background-image: linear-gradient(rgba(255,255,255,.15), rgba(0,0,0,.1));
+    box-shadow: 0 -1px 0 0 rgba(0,0,0,.05) inset,
                 0 0 0 1px  rgba(0,0,0,.13) inset,
-                0 1px 3px  rgba(0,0,0,.05));
+                0 1px 3px  rgba(0,0,0,.05);
     text-shadow: 0px 1px 0px rgba(255,255,255,.9);
 
     // Apply consistent transitions for more smooth animations.
-    .transition(opacity .1s ease,
+    transition: opacity .1s ease,
                 background-color .1s ease,
                 box-shadow .1s ease,
-                color .1s ease);
+                color .1s ease;
 
 
     &:hover {
         color: rgba(0,0,0,.8);
         background-color: #e0e0e0;
-        .background-image(linear-gradient(rgba(0,0,0,0), rgba(0,0,0,.08)));
-        .box-shadow(0 -1px 0 0 rgba(0,0,0,.05) inset,
+        background-image: linear-gradient(rgba(0,0,0,0), rgba(0,0,0,.08));
+        box-shadow: 0 -1px 0 0 rgba(0,0,0,.05) inset,
                     0 0 0 1px  rgba(0,0,0,.13) inset,
-                    0 1px 3px  rgba(0,0,0,.15) inset);
+                    0 1px 3px  rgba(0,0,0,.15) inset;
         text-shadow: 0px 1px 0px rgba(255,255,255,.7);
     }
 
@@ -46,18 +46,18 @@
     &:active {
         color: rgba(0,0,0,.9);
         background-color: #babbbc;
-        .box-shadow(0 -1px 0 0 rgba(0,0,0,.05) inset,
+        box-shadow: 0 -1px 0 0 rgba(0,0,0,.05) inset,
                     0 0 0 1px  rgba(0,0,0,.13) inset,
-                    0 3px 5px  rgba(0,0,0,.15) inset);
+                    0 3px 5px  rgba(0,0,0,.15) inset;
         text-shadow: 0px 1px 0px rgba(255,255,255,.5);
     }
 
 
     &:focus {
         color: rgba(0,0,0,.9);
-        .box-shadow(0 -1px 0 0 rgba(0,0,0,.05) inset,
+        box-shadow: 0 -1px 0 0 rgba(0,0,0,.05) inset,
                     0 0 0 1px  rgba(81,167,232,1) inset,
-                    0 1px 3px  rgba(81,167,232,.5));
+                    0 1px 3px  rgba(81,167,232,.5);
         text-shadow: 0px 1px 0px rgba(255,255,255,.7);
     }
 

--- a/app/static/stylesheets/components/nav.less
+++ b/app/static/stylesheets/components/nav.less
@@ -2,7 +2,8 @@
 
 
 .nav {
-    a {
+
+    &__link {
         // Make navigation menu a little bigger for better usability.
         padding: @unit/2;
     }

--- a/app/static/stylesheets/components/page-masthead.less
+++ b/app/static/stylesheets/components/page-masthead.less
@@ -19,7 +19,7 @@
 
 
     // Pull navigation to the right.
-    .nav {
+    &__nav {
         float: right;
     }
 }

--- a/app/static/stylesheets/main.less
+++ b/app/static/stylesheets/main.less
@@ -10,7 +10,6 @@
 // Mixins and aliases.
 @import 'classy-clearfix/generic.clearfix.less';
 @import 'classy-snippets/generic.snippets.less';
-@import 'lesshat/build/lesshat';
 @import 'generic/reset';
 
 

--- a/app/static/stylesheets/main.less
+++ b/app/static/stylesheets/main.less
@@ -18,10 +18,9 @@
 
 
 // Base page constrain and per element styling.
-@import 'classy-images/base.images.less';
-@import 'classy-lists/base.lists.less';
-@import 'classy-page/base.page.less';
-@import 'classy-typography/base.typography.less';
+@import 'classy-lists/elements.lists.less';
+@import 'classy-page/elements.page.less';
+@import 'classy-typography/elements.typography.less';
 @import 'elements/headings';
 @import 'elements/links';
 @import 'elements/page';

--- a/app/templates/layout.html
+++ b/app/templates/layout.html
@@ -24,7 +24,11 @@
         <nav role="navigation">
           {% block navigation %}
           <ul class="nav">
-            <li><a href="https://github.com/vitalk/flask-styleguide-example">View code on <strong>GitHub</strong></a></li>
+            <li class="nav__item">
+              <a class="nav__link" href="https://github.com/vitalk/flask-styleguide-example">
+                View code on <strong>GitHub</strong>
+              </a>
+            </li>
           </ul>
           {% endblock %}
         </nav>

--- a/app/templates/layout.html
+++ b/app/templates/layout.html
@@ -28,7 +28,7 @@
       <div class="wrapper">
         <nav role="navigation">
           {% block navigation %}
-          <ul class="nav">
+          <ul class="page-masthead__nav nav">
             <li class="nav__item">
               <a class="nav__link" href="https://github.com/vitalk/flask-styleguide-example">
                 View code on <strong>GitHub</strong>

--- a/app/templates/layout.html
+++ b/app/templates/layout.html
@@ -1,13 +1,18 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
-    <meta charset="utf-8" />
-    <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1" />
-    <meta name="viewport" content="width=device-width" />
+    <meta charset="utf-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
+    <meta name="viewport" content="width=device-width">
     <title>{% block page_title %}{{ page_title ~ ' | ' if page_title }}Living Styleguide{% endblock %}</title>
 
     {% block meta %}
-    <meta name="author" content="Vital Kudzelka" />
+    <meta name="author" content="Vital Kudzelka">
+    <meta name="description" content="Example of living Styleguide made with Flask-Styleguide and Frozen-Flask">
+    <meta property="og:url" content="https://vitalk.github.io/flask-styleguide-example/">
+    <meta property="og:type" content="website">
+    <meta property="og:site_name" content="Example of living Styleguide">
+    <meta property="og:description" content="Example of living Styleguide made with Flask-Styleguide and Frozen-Flask">
     {% endblock %}
 
     {% block cssmain %}

--- a/app/templates/styleguide/section.html
+++ b/app/templates/styleguide/section.html
@@ -1,10 +1,10 @@
 <article class="style-guide" id="{{ section.section }}">
-  <h4 class="style-guide-reference">{{ section.section }}</h4>
+  <h4 class="style-guide__reference">{{ section.section }}</h4>
 
-  <div class="style-guide-description">
+  <div class="style-guide__description">
     <p>{{ section.description|safe }}</p>
     {% if section.modifiers %}
-      <ul class="style-guide-modifiers">
+      <ul class="style-guide__modifiers">
         {% for m in section.modifiers %}
           <li><strong>{{ m.name }}</strong> - {{ m.description }}</li>
         {% endfor %}
@@ -12,18 +12,18 @@
     {% endif %}
   </div>
 
-  <div class="style-guide-element">
+  <div class="style-guide__element">
     {{ section.example|safe }}
   </div>
 
   {% for m in section.modifiers %}
-    <div class="style-guide-element">
-      <small class="style-guide-modifier">{{ m.name }}</small>
+    <div class="style-guide__element">
+      <small class="style-guide__modifier">{{ m.name }}</small>
       {{ m.example|safe }}
     </div>
   {% endfor %}
 
-  <div class="style-guide-html">
+  <div class="style-guide__html">
     <pre>{{ section.example|forceescape }}</pre>
   </div>
 </article>

--- a/bower.json
+++ b/bower.json
@@ -18,7 +18,7 @@
     "classy-page": "~0.1.0",
     "classy-snippets": "~0.1.0",
     "classy-sticky-footer": "~0.1.0",
-    "classy-style-guide": "~0.0.6",
+    "classy-style-guide": "~0.1.0",
     "classy-typography": "~0.1.4",
     "lesshat": "~3.0.2"
   }

--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "flask-styleguide-example",
-  "version": "0.3.1",
+  "version": "0.4.0",
   "authors": [
     "Vital Kudzelka <vital.kudzelka@gmail.com>"
   ],

--- a/bower.json
+++ b/bower.json
@@ -18,8 +18,7 @@
     "classy-page": "~0.1.0",
     "classy-snippets": "~0.1.0",
     "classy-sticky-footer": "~0.1.0",
-    "classy-style-guide": "~0.1.0",
-    "classy-typography": "~0.1.4",
-    "lesshat": "~3.0.2"
+    "classy-style-guide": "~0.2.1",
+    "classy-typography": "~0.1.4"
   }
 }

--- a/bower.json
+++ b/bower.json
@@ -4,7 +4,7 @@
   "authors": [
     "Vital Kudzelka <vital.kudzelka@gmail.com>"
   ],
-  "description": "Example of Live Style Guide made with Flask-Styleguide.",
+  "description": "Example of living Styleguide made with Flask-Styleguide.",
   "license": "MIT",
   "homepage": "https://github.com/vitalk/flask-styleguide-example",
   "private": true,

--- a/bower.json
+++ b/bower.json
@@ -12,13 +12,13 @@
     "classy-border-box": "~0.1.0",
     "classy-clearfix": "~0.1.1",
     "classy-defaults": "~0.2.2",
-    "classy-lists": "~0.1.1",
+    "classy-lists": "~0.2.0",
     "classy-media-queries": "~0.1.0",
-    "classy-nav": "~0.2.0",
-    "classy-page": "~0.1.0",
+    "classy-nav": "~0.3.1",
+    "classy-page": "~0.2.0",
     "classy-snippets": "~0.1.0",
     "classy-sticky-footer": "~0.1.0",
     "classy-style-guide": "~0.2.1",
-    "classy-typography": "~0.1.4"
+    "classy-typography": "~0.2.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -7,12 +7,14 @@
   "homepage": "https://github.com/vitalk/flask-styleguide-example",
   "private": true,
   "devDependencies": {
+    "autoprefixer": "^6.5.3",
     "bower": "^1.4.1",
     "grunt": "^0.4.5",
     "grunt-cli": "^0.1.13",
     "grunt-contrib-clean": "^0.6.0",
     "grunt-contrib-connect": "^0.9.0",
     "grunt-contrib-watch": "^0.6.1",
-    "less": "^2.5.0"
+    "less": "^2.5.0",
+    "postcss-cli": "^2.6.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "flask-styleguide-example",
-  "version": "0.3.1",
+  "version": "0.4.0",
   "author": "Vital Kudzelka <vital.kudzelka@gmail.com>",
   "description": "Example of living Styleguide made with Flask-Styleguide.",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "flask-styleguide-example",
   "version": "0.3.1",
   "author": "Vital Kudzelka <vital.kudzelka@gmail.com>",
-  "description": "Example of Live Style Guide made with Flask-Styleguide.",
+  "description": "Example of living Styleguide made with Flask-Styleguide.",
   "license": "MIT",
   "homepage": "https://github.com/vitalk/flask-styleguide-example",
   "private": true,


### PR DESCRIPTION
- [x] Use `classy-style-guide@0.1.0` (with BEM naming for style guide section)

- [x] Drop `lesshat` from dependencies (for the sake of `autoprefixer`)

- [x] Update `classy-*` dependencies

- [x] Update bower/npm package description for consistency with `Flask-Styleguide`

- [x] Set readable page metadata